### PR TITLE
インクリメンタルサーチの実装

### DIFF
--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -1,0 +1,71 @@
+$(function(){
+  function  addUser(user) {
+    let html = `
+      <div class="chat-group-user clearfix">
+        <p class="chat-group-user__name">${user.name}</p>
+        <div class="user-search-add chat-group-user__btn chat-group-user__btn--add" data-user-id="${user.id}" data-user-name="${user.name}">追加</div>
+      </div>
+    `;
+    $("#user-search-result").append(html);
+  }
+
+  function  addNoUser() {
+    let html = `
+      <div class="chat-group-user clearfix">
+        <p class="chat-group-user__name">ユーザーが見つかりません</p>
+      </div>
+    `;
+    $("#user-search-result").append(html);
+  }
+
+  function addDeleteUser(name, id) {
+    let html = `
+      <div class="chat-group-user clearfix" id="${id}">
+        <p class="chat-group-user__name">${name}</p>
+        <div class="user-search-remove chat-group-user__btn chat-group-user__btn--remove js-remove-btn" data-user-id="${id}" data-user-name="${name}">削除</div>
+      </div>`;
+      $(".js-add-user").append(html);
+  }
+  function addMember(userId) {
+    let html = `<input value="${userId}" name="group[user_ids][]" type="hidden" id="group_user_ids_${userId}" />`;
+    $(`#${userId}`).append(html);
+  }
+  $("#user-search-field").on("keyup", function(){
+    let input = $("#user-search-field").val();
+    $.ajax({
+      type: "GET",
+      url: "/users",
+      data: { keyword: input },
+      dataType: 'json',
+    })
+    .done(function(users) {
+      $("#user-search-result").empty();
+      if (users.length !== 0) {
+        users.forEach(function(user) {
+          addUser(user);
+        });
+      } else if (input.length == 0) {
+        return false;
+      } else {
+        addNoUser();
+      }
+    })
+    .fail(function() {
+      alert("通信エラーです。ユーザー検索に失敗しました");
+    });
+  });
+  $(document).on("click", ".chat-group-user__btn--add", function() {
+    const userName = $(this).attr("data-user-name");
+    const userId = $(this).attr("data-user-id");
+    $(this)
+      .parent()
+      .remove();
+    addDeleteUser(userName, userId);
+    addMember(userId);
+  });
+  $(document).on("click", ".chat-group-user__btn--remove", function() {
+    $(this)
+      .parent()
+      .remove();
+  });
+});

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,14 @@
 class UsersController < ApplicationController
+
+  def index
+    return nil if params[:keyword] == ""
+    @users = User.where(['name LIKE ?', "%#{params[:keyword]}%"] ).where.not(id: current_user.id).limit(10)
+    respond_to do |format|
+      format.html
+      format.json
+    end
+  end
+
   def edit
   end
 

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -10,15 +10,33 @@
       = f.label :name, class: 'chat-group-form__label'
     .chat-group-form__field--right
       = f.text_field :name, class: 'chat__group_name chat-group-form__input', placeholder: 'グループ名を入力してください'
-  .chat-group-form__field.clearfix
-    / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
+  .chat-group-form__field
+    .chat-group-form__field--left
+      %label.chat-group-form__label{:for => "chat_group_チャットメンバーを追加"} チャットメンバーを追加
+    .chat-group-form__field--right
+      .chat-group-form__search.clearfix
+        %input#user-search-field.chat-group-form__input{:placeholder => "追加したいユーザー名を入力してください", :type => "text"}/
+      #user-search-result
+
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
       %label.chat-group-form__label{:for => "chat_group_チャットメンバー"} チャットメンバー
     .chat-group-form__field--right
-      / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
-      = f.collection_check_boxes :user_ids, User.all, :id, :name
-      / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
+
+      #chat-group-users.js-add-user
+        .chat-group-user.clearfix.js-chat-member
+          %input{name: "group[user_ids][]", type: "hidden", value: current_user.id}
+          %p.chat-group-user__name= current_user.name
+
+        - group.users.each do |user|
+          - if current_user.name != user.name
+            .chat-group-user.clearfix.js-chat-member
+              %input{name: "group[user_ids][]", type: "hidden", value: user.id}
+              %p.chat-group-user__name
+                = user.name
+              %a.user-search-remove.chat-group-user__btn.chat-group-user__btn--remove.js-remove-btn
+                削除
+
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
     .chat-group-form__field--right

--- a/app/views/users/index.json.jbuilder
+++ b/app/views/users/index.json.jbuilder
@@ -1,0 +1,4 @@
+json.array! @users do |user|
+  json.id  user.id
+  json.name  user.name
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
   root "groups#index"
-  resources :users, only: [:edit, :update]
+  resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
   end


### PR DESCRIPTION
#What
グループ新規作成の際に、チャットメンバー検索をインクリメンタルサーチできるように実装した。
![14392ac9d2e60a011f64b225f9e25d77](https://user-images.githubusercontent.com/60601986/74404555-34f40d80-4e6e-11ea-8220-5091ac6ebff5.gif)


#Why
チャットメンバーを検索する際に、キーワードが一致するユーザーを非同期で表示し、追加・削除することでグループの作成・編集を容易にするため。